### PR TITLE
Fix memory bloat from ComposerCollector

### DIFF
--- a/src/ComposerCollector.php
+++ b/src/ComposerCollector.php
@@ -180,12 +180,9 @@ class ComposerCollector implements Collector
         return FileNode::class;
     }
 
-    /**
-     * @return RuleError[]
-     */
-    public function processNode(Node $node, Scope $scope): array
+    public function processNode(Node $node, Scope $scope)
     {
         // We're not actually processing nodes, we just are using a Collector have this run once per analyze run
-        return [];
+        return null;
     }
 }


### PR DESCRIPTION
a collector should either return a valid result or `null` - because the returned value is persisted in PHPStan result cache (except for `null`). therefore you should not return things like `[]`, as this would get serialized per AST node your collector works on.

thats something I learned today and in one of our projects it lead to out-of-memory fatal errors.

for in-detail context see https://github.com/phpstan/phpstan/discussions/11701#discussioncomment-10660711