### PR TITLE
Support baselining of PHPStan errors on composer.json

### DIFF
--- a/src/ComposerCollector.php
+++ b/src/ComposerCollector.php
@@ -76,7 +76,7 @@ class ComposerCollector implements Collector
         $composerJson = $initializer->initComposerJson(options: $options);
         $initializer->initComposerAutoloader(composerJson: $composerJson);
         $configuration = $initializer->initConfiguration(options: $options, composerJson: $composerJson);
-        $this->composerJsonPath = dirname($composerJson->composerVendorDir) .'/composer.json';
+        $this->composerJsonPath = dirname($composerJson->composerVendorDir).'/composer.json';
 
         $configuration->ignoreErrors([ErrorType::UNKNOWN_CLASS, ErrorType::UNKNOWN_FUNCTION]);
 

--- a/src/ComposerCollector.php
+++ b/src/ComposerCollector.php
@@ -23,6 +23,8 @@ class ComposerCollector implements Collector
 
     private string $cwd;
 
+    private string $composerJsonPath;
+
     /** @var string[] */
     private array $additionalProdPaths = [];
 
@@ -74,6 +76,7 @@ class ComposerCollector implements Collector
         $composerJson = $initializer->initComposerJson(options: $options);
         $initializer->initComposerAutoloader(composerJson: $composerJson);
         $configuration = $initializer->initConfiguration(options: $options, composerJson: $composerJson);
+        $this->composerJsonPath = dirname($composerJson->composerVendorDir) .'/composer.json';
 
         $configuration->ignoreErrors([ErrorType::UNKNOWN_CLASS, ErrorType::UNKNOWN_FUNCTION]);
 
@@ -142,14 +145,14 @@ class ComposerCollector implements Collector
             ),
             array_map(
                 fn ($error) => RuleErrorBuilder::message("Prod dependency used only in dev paths: {$error}")
-                    ->file('composer.json')
+                    ->file($this->composerJsonPath)
                     ->tip('This should probably be moved to "require-dev" section in composer.json')
                     ->identifier('composer.prodInDev')
                     ->build(),
                 $results->getProdDependencyOnlyInDevErrors()),
             array_map(
                 fn ($error) => RuleErrorBuilder::message("Unused dependency detected: {$error}")
-                    ->file('composer.json')
+                    ->file($this->composerJsonPath)
                     ->tip('This is listed in composer.json, but no usage was found in scanned paths')
                     ->identifier('composer.unused')
                     ->build(),


### PR DESCRIPTION
before this PR errors in the `composer.json` file could not be [baselined using the regular PHPStan mechanism](https://phpstan.org/user-guide/baseline).

while errors were written into the baseline PHPStan did not ignore the error as the path to the files were not accurate.

after this PR we are able to ignore errors related to `composer.json` like any other error